### PR TITLE
feat: add publication status dropdown filter and favorite creation date tracking

### DIFF
--- a/.github/workflows/new-commit-discord.yml
+++ b/.github/workflows/new-commit-discord.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Send commit embed to Discord
         env:
           WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
+          REPO_FULL_NAME: ${{ github.repository }}
           REPO: ${{ github.event.repository.name }}
           COMMIT_URL: ${{ github.event.head_commit.url }}
           COMMIT_MSG: ${{ github.event.head_commit.message }}
@@ -19,8 +21,27 @@ jobs:
           BRANCH: ${{ github.ref_name }}
           TIMESTAMP: ${{ github.event.head_commit.timestamp }}
         run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "No DISCORD_WEBHOOK_URL secret configured, skipping notification."
+            exit 0
+          fi
+
+          DEFAULT_ROLE_ID="1507819392233242624"
+          ROLE_ID="$DISCORD_ROLE_ID"
+          if [ -z "$ROLE_ID" ] && [ "$REPO_FULL_NAME" = "glitch-228/Kaisoku" ]; then
+            ROLE_ID="$DEFAULT_ROLE_ID"
+          fi
+
+          CONTENT=""
+          ROLE_MENTIONS="[]"
+          if [ -n "$ROLE_ID" ]; then
+            CONTENT="<@&${ROLE_ID}>"
+            ROLE_MENTIONS="[\"${ROLE_ID}\"]"
+          fi
+
           jq -n \
-            --arg content "<@&1507819392233242624>" \
+            --arg content "$CONTENT" \
+            --argjson roles "$ROLE_MENTIONS" \
             --arg title "New Commit: ${REPO}" \
             --arg url "${COMMIT_URL}" \
             --arg description "${COMMIT_MSG}" \
@@ -30,7 +51,7 @@ jobs:
             --arg timestamp "${TIMESTAMP}" \
             '{
               content: $content,
-              allowed_mentions: { roles: ["1507819392233242624"] },
+              allowed_mentions: { roles: $roles },
               embeds: [{
                 title: $title,
                 url: $url,

--- a/.github/workflows/new-issue-discord.yml
+++ b/.github/workflows/new-issue-discord.yml
@@ -19,6 +19,10 @@ jobs:
           NUMBER: ${{ github.event.issue.number }}
           TIMESTAMP: ${{ github.event.issue.created_at }}
         run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "No DISCORD_ISSUE_WEBHOOK secret configured, skipping notification."
+            exit 0
+          fi
           # Discord caps embed description at 4096 chars (total embed 6000). Crash-report
           # bodies dwarf that and Discord answers 400 — silently killing the webhook.
           # Truncate with headroom so we never trip the limit.

--- a/.github/workflows/new-release-discord.yml
+++ b/.github/workflows/new-release-discord.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Send release embed to Discord
         env:
           WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          DISCORD_ROLE_ID: ${{ secrets.DISCORD_RELEASE_ROLE_ID || secrets.DISCORD_ROLE_ID }}
+          REPO_FULL_NAME: ${{ github.repository }}
           REPO: ${{ github.event.repository.name }}
           TAG: ${{ github.event.release.tag_name }}
           URL: ${{ github.event.release.html_url }}
@@ -24,13 +26,32 @@ jobs:
           ACTOR: ${{ github.actor }}
           TIMESTAMP: ${{ github.event.release.published_at }}
         run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "No DISCORD_RELEASE_WEBHOOK secret configured, skipping notification."
+            exit 0
+          fi
+
+          DEFAULT_ROLE_ID="1506992583744684175"
+          ROLE_ID="$DISCORD_ROLE_ID"
+          if [ -z "$ROLE_ID" ] && [ "$REPO_FULL_NAME" = "glitch-228/Kaisoku" ]; then
+            ROLE_ID="$DEFAULT_ROLE_ID"
+          fi
+
+          CONTENT=""
+          ROLE_MENTIONS="[]"
+          if [ -n "$ROLE_ID" ]; then
+            CONTENT="<@&${ROLE_ID}>"
+            ROLE_MENTIONS="[\"${ROLE_ID}\"]"
+          fi
+
           # Discord caps embed description at 4096 chars; release notes can grow past that.
           DESC="${BODY}"
           if [ ${#DESC} -gt 3800 ]; then
             DESC="${DESC:0:3800}"$'\n\n'"…(truncated; open the release for full notes)"
           fi
           jq -n \
-            --arg content "<@&1506992583744684175>" \
+            --arg content "$CONTENT" \
+            --argjson roles "$ROLE_MENTIONS" \
             --arg title "🚀 New Release: ${REPO} v${TAG}" \
             --arg url "${URL}" \
             --arg description "${DESC}" \
@@ -40,7 +61,7 @@ jobs:
             --arg timestamp "${TIMESTAMP}" \
             '{
               content: $content,
-              allowed_mentions: { roles: ["1506992583744684175"] },
+              allowed_mentions: { roles: $roles },
               embeds: [{
                 title: $title,
                 url: $url,
@@ -60,6 +81,8 @@ jobs:
       - name: Send prerelease embed to Discord
         env:
           WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          DISCORD_ROLE_ID: ${{ secrets.DISCORD_RELEASE_ROLE_ID || secrets.DISCORD_ROLE_ID }}
+          REPO_FULL_NAME: ${{ github.repository }}
           REPO: ${{ github.event.repository.name }}
           TAG: ${{ github.event.release.tag_name }}
           URL: ${{ github.event.release.html_url }}
@@ -67,11 +90,27 @@ jobs:
           ACTOR: ${{ github.actor }}
           TIMESTAMP: ${{ github.event.release.published_at }}
         run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "No DISCORD_RELEASE_WEBHOOK secret configured, skipping notification."
+            exit 0
+          fi
+
+          ROLE_ID="$DISCORD_ROLE_ID"
+
+          CONTENT=""
+          ROLE_MENTIONS="[]"
+          if [ -n "$ROLE_ID" ]; then
+            CONTENT="<@&${ROLE_ID}>"
+            ROLE_MENTIONS="[\"${ROLE_ID}\"]"
+          fi
+
           DESC="${BODY}"
           if [ ${#DESC} -gt 3800 ]; then
             DESC="${DESC:0:3800}"$'\n\n'"…(truncated; open the release for full notes)"
           fi
           jq -n \
+            --arg content "$CONTENT" \
+            --argjson roles "$ROLE_MENTIONS" \
             --arg title "🧪 Pre-Release: ${REPO} ${TAG}" \
             --arg url "${URL}" \
             --arg description "${DESC}" \
@@ -80,7 +119,8 @@ jobs:
             --arg footer "Pre-release build" \
             --arg timestamp "${TIMESTAMP}" \
             '{
-              allowed_mentions: { parse: [] },
+              content: $content,
+              allowed_mentions: { roles: $roles },
               embeds: [{
                 title: $title,
                 url: $url,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/domain/DetailsInteractor.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/domain/DetailsInteractor.kt
@@ -38,6 +38,10 @@ class DetailsInteractor @Inject constructor(
 		return favouritesRepository.observeCategories(mangaId)
 	}
 
+	fun observeFavoriteDate(mangaId: Long): Flow<Long?> {
+		return favouritesRepository.observeFavoriteDate(mangaId)
+	}
+
 	fun observeNewChapters(mangaId: Long): Flow<Int> {
 		return settings.observeAsFlow(AppSettings.KEY_TRACKER_ENABLED) { isTrackerEnabled }
 			.flatMapLatest { isEnabled ->

--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsActivity.kt
@@ -17,6 +17,9 @@ import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.core.text.buildSpannedString
 import androidx.core.text.inSpans
+import android.text.format.DateFormat
+import android.widget.LinearLayout
+import java.util.Date
 import androidx.core.text.method.LinkMovementMethodCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
@@ -203,6 +206,7 @@ class DetailsActivity :
 		viewModel.localSize.observe(this, ::onLocalSizeChanged)
 		viewModel.relatedManga.observe(this, ::onRelatedMangaChanged)
 		viewModel.favouriteCategories.observe(this, ::onFavoritesChanged)
+		viewModel.favoriteDate.observe(this, ::onFavoriteDateChanged)
 		val menuInvalidator = MenuInvalidator(this)
 		viewModel.isStatsAvailable.observe(this, menuInvalidator)
 		viewModel.remoteManga.observe(this, menuInvalidator)
@@ -388,6 +392,17 @@ class DetailsActivity :
 		}
 	}
 
+	private fun onFavoriteDateChanged(date: Long?) {
+		if (date != null && date > 0L) {
+			val dateStr = DateFormat.getDateFormat(this).format(Date(date))
+			infoBinding.textViewFavouriteDate.text = dateStr
+			infoBinding.metaFavouriteCell.isVisible = true
+		} else {
+			infoBinding.metaFavouriteCell.isVisible = false
+		}
+		updateMetaTableLayout()
+	}
+
 	private fun onLocalSizeChanged(size: Long) {
 		if (size == 0L) {
 			infoBinding.metaLocalCell.isVisible = false
@@ -395,8 +410,47 @@ class DetailsActivity :
 			infoBinding.textViewLocal.text = FileSize.BYTES.format(this, size)
 			infoBinding.metaLocalCell.isVisible = true
 		}
-		infoBinding.metaRatingLocalRow.isVisible =
-			infoBinding.metaRatingCell.isVisible || infoBinding.metaLocalCell.isVisible
+		updateMetaTableLayout()
+	}
+
+	private fun updateMetaTableLayout() {
+		val isLocalVisible = infoBinding.metaLocalCell.isVisible
+		val isFavouriteVisible = infoBinding.metaFavouriteCell.isVisible
+
+		val params = infoBinding.metaFavouriteCell.layoutParams as? LinearLayout.LayoutParams
+
+		if (isFavouriteVisible && !isLocalVisible) {
+			if (infoBinding.metaFavouriteCell.parent != infoBinding.metaRatingLocalRow) {
+				(infoBinding.metaFavouriteCell.parent as? ViewGroup)?.removeView(infoBinding.metaFavouriteCell)
+				infoBinding.metaRatingLocalRow.addView(infoBinding.metaFavouriteCell)
+			}
+			if (params != null) {
+				params.width = 0
+				params.weight = 1f
+				infoBinding.metaFavouriteCell.layoutParams = params
+			}
+			infoBinding.metaFavouriteRow.isVisible = false
+			infoBinding.metaRatingLocalRow.isVisible = true
+		} else if (isFavouriteVisible && isLocalVisible) {
+			if (infoBinding.metaFavouriteCell.parent != infoBinding.metaFavouriteRow) {
+				(infoBinding.metaFavouriteCell.parent as? ViewGroup)?.removeView(infoBinding.metaFavouriteCell)
+				infoBinding.metaFavouriteRow.addView(infoBinding.metaFavouriteCell)
+			}
+			if (params != null) {
+				params.width = ViewGroup.LayoutParams.MATCH_PARENT
+				params.weight = 0f
+				infoBinding.metaFavouriteCell.layoutParams = params
+			}
+			infoBinding.metaFavouriteRow.isVisible = true
+			infoBinding.metaRatingLocalRow.isVisible = true
+		} else {
+			if (infoBinding.metaFavouriteCell.parent != infoBinding.metaFavouriteRow) {
+				(infoBinding.metaFavouriteCell.parent as? ViewGroup)?.removeView(infoBinding.metaFavouriteCell)
+				infoBinding.metaFavouriteRow.addView(infoBinding.metaFavouriteCell)
+			}
+			infoBinding.metaFavouriteRow.isVisible = false
+			infoBinding.metaRatingLocalRow.isVisible = infoBinding.metaRatingCell.isVisible || isLocalVisible
+		}
 	}
 
 	private fun onRelatedMangaChanged(related: List<MangaListModel>) {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsViewModel.kt
@@ -102,6 +102,10 @@ class DetailsViewModel @Inject constructor(
 		.withErrorHandling()
 		.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, emptySet())
 
+	val favoriteDate = interactor.observeFavoriteDate(mangaId)
+		.withErrorHandling()
+		.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, null)
+
 	val isStatsAvailable = statsRepository.observeHasStats(mangaId)
 		.withErrorHandling()
 		.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, false)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouritesDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouritesDao.kt
@@ -1,6 +1,7 @@
 package org.koitharu.kotatsu.favourites.data
 
 import android.database.DatabaseUtils.sqlEscapeString
+import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
@@ -127,6 +128,12 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 
 	@Query("SELECT COUNT(DISTINCT manga_id) FROM favourites WHERE deleted_at = 0")
 	abstract fun observeMangaCount(): Flow<Int>
+
+	@Query("SELECT MIN(created_at) FROM favourites WHERE manga_id = :mangaId AND deleted_at = 0")
+	abstract fun observeFavoriteDate(mangaId: Long): Flow<Long?>
+
+	@Query("SELECT category_id, created_at FROM favourites WHERE manga_id = :mangaId AND deleted_at = 0")
+	abstract suspend fun findCategoryDates(mangaId: Long): List<CategoryDateEntity>
 
 	@Query("SELECT * FROM favourites WHERE manga_id = :mangaId AND deleted_at = 0")
 	abstract suspend fun findAllRaw(mangaId: Long): List<FavouriteEntity>
@@ -305,3 +312,8 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 		return sources.takeUnless { it == "manga.source IN ()" } ?: "0"
 	}
 }
+
+data class CategoryDateEntity(
+	@ColumnInfo(name = "category_id") val categoryId: Long,
+	@ColumnInfo(name = "created_at") val createdAt: Long,
+)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/domain/FavouritesRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/domain/FavouritesRepository.kt
@@ -148,6 +148,14 @@ class FavouritesRepository @Inject constructor(
 		}
 	}
 
+	fun observeFavoriteDate(mangaId: Long): Flow<Long?> {
+		return db.getFavouritesDao().observeFavoriteDate(mangaId).distinctUntilChanged()
+	}
+
+	suspend fun getCategoryDates(mangaId: Long): Map<Long, Long> {
+		return db.getFavouritesDao().findCategoryDates(mangaId).associateBy({ it.categoryId }, { it.createdAt })
+	}
+
 	suspend fun getCategory(id: Long): FavouriteCategory {
 		return db.getFavouriteCategoriesDao().find(id.toInt()).toFavouriteCategory()
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/ui/categories/select/FavoriteDialogViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/ui/categories/select/FavoriteDialogViewModel.kt
@@ -77,15 +77,22 @@ class FavoriteDialogViewModel @Inject constructor(
 			val ids = favouritesRepository.getCategoriesIds(m.id)
 			ids.forEach { id -> cats[id]?.add(m.id) }
 		}
+		val categoryDates = if (manga.size == 1) {
+			favouritesRepository.getCategoryDates(manga[0].id)
+		} else {
+			emptyMap()
+		}
 		return categories.map { cat ->
+			val checkedState = when (cats[cat.id]?.size ?: 0) {
+				0 -> MaterialCheckBox.STATE_UNCHECKED
+				manga.size -> MaterialCheckBox.STATE_CHECKED
+				else -> MaterialCheckBox.STATE_INDETERMINATE
+			}
 			MangaCategoryItem(
 				category = cat,
-				checkedState = when (cats[cat.id]?.size ?: 0) {
-					0 -> MaterialCheckBox.STATE_UNCHECKED
-					manga.size -> MaterialCheckBox.STATE_CHECKED
-					else -> MaterialCheckBox.STATE_INDETERMINATE
-				},
+				checkedState = checkedState,
 				isTrackerEnabled = tracker,
+				addedAt = if (checkedState == MaterialCheckBox.STATE_CHECKED) categoryDates[cat.id] else null,
 			)
 		}
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/ui/categories/select/adapter/MangaCategoryAD.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/ui/categories/select/adapter/MangaCategoryAD.kt
@@ -1,6 +1,10 @@
 package org.koitharu.kotatsu.favourites.ui.categories.select.adapter
 
+import android.text.format.DateFormat
+import android.widget.Toast
 import androidx.core.text.buildSpannedString
+import androidx.core.view.isVisible
+import com.google.android.material.checkbox.MaterialCheckBox
 import com.hannesdorfmann.adapterdelegates4.dsl.adapterDelegateViewBinding
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.model.appendIcon
@@ -9,6 +13,7 @@ import org.koitharu.kotatsu.databinding.ItemCategoryCheckableBinding
 import org.koitharu.kotatsu.favourites.ui.categories.select.model.MangaCategoryItem
 import org.koitharu.kotatsu.list.ui.ListModelDiffCallback
 import org.koitharu.kotatsu.list.ui.model.ListModel
+import java.util.Date
 
 fun mangaCategoryAD(
 	clickListener: OnListItemClickListener<MangaCategoryItem>,
@@ -20,8 +25,28 @@ fun mangaCategoryAD(
 		clickListener.onItemClick(item, itemView)
 	}
 
+	itemView.setOnLongClickListener {
+		val addedAt = item.addedAt
+		if (item.checkedState == MaterialCheckBox.STATE_CHECKED && addedAt != null && addedAt > 0L) {
+			val dateStr = DateFormat.getDateFormat(context).format(Date(addedAt))
+			val timeStr = DateFormat.getTimeFormat(context).format(Date(addedAt))
+			val msg = context.getString(R.string.added_to_category_at, item.category.title, "$dateStr, $timeStr")
+			Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+			true
+		} else {
+			false
+		}
+	}
+
 	bind { payloads ->
 		binding.checkBox.checkedState = item.checkedState
+		val addedAt = item.addedAt
+		if (item.checkedState == MaterialCheckBox.STATE_CHECKED && addedAt != null && addedAt > 0L) {
+			binding.textViewDate.text = DateFormat.getDateFormat(context).format(Date(addedAt))
+			binding.textViewDate.isVisible = true
+		} else {
+			binding.textViewDate.isVisible = false
+		}
 		if (ListModelDiffCallback.PAYLOAD_CHECKED_CHANGED !in payloads) {
 			binding.checkBox.text = buildSpannedString {
 				append(item.category.title)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/ui/categories/select/model/MangaCategoryItem.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/ui/categories/select/model/MangaCategoryItem.kt
@@ -9,6 +9,7 @@ data class MangaCategoryItem(
 	val category: FavouriteCategory,
 	@CheckedState val checkedState: Int,
 	val isTrackerEnabled: Boolean,
+	val addedAt: Long? = null,
 ) : ListModel {
 
 	override fun areItemsTheSame(other: ListModel): Boolean {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/MangaListQuickFilter.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/MangaListQuickFilter.kt
@@ -28,11 +28,16 @@ abstract class MangaListQuickFilter(
 	var isStateFilterEnabled = true
 
 	override fun setFilterOption(option: ListFilterOption, isApplied: Boolean) {
-		appliedFilter.value = ArraySet(appliedFilter.value).also {
-			if (isApplied) {
-				it.addNoConflicts(option)
+		appliedFilter.value = ArraySet(appliedFilter.value).also { options ->
+			if (option is ListFilterOption.State) {
+				options.removeIf { it is ListFilterOption.State }
+				if (isApplied && option.state != null) {
+					options.add(option)
+				}
+			} else if (isApplied) {
+				options.addNoConflicts(option)
 			} else {
-				it.remove(option)
+				options.remove(option)
 			}
 		}
 	}
@@ -83,6 +88,7 @@ abstract class MangaListQuickFilter(
 			titleResId = current?.state?.titleResId ?: R.string.publication_status,
 			icon = current?.state?.iconResId ?: R.drawable.ic_filter_menu,
 			isChecked = current != null,
+			isDropdown = true,
 			data = current ?: ListFilterOption.State(null),
 		)
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/MangaListFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/MangaListFragment.kt
@@ -43,6 +43,9 @@ import org.koitharu.kotatsu.core.util.ext.observe
 import org.koitharu.kotatsu.core.util.ext.observeEvent
 import org.koitharu.kotatsu.core.util.ext.viewLifecycleScope
 import org.koitharu.kotatsu.databinding.FragmentListBinding
+import androidx.appcompat.widget.PopupMenu
+import org.koitharu.kotatsu.core.model.titleResId
+import org.koitharu.kotatsu.parsers.model.MangaState
 import org.koitharu.kotatsu.list.domain.ListFilterOption
 import org.koitharu.kotatsu.list.domain.QuickFilterListener
 import org.koitharu.kotatsu.list.ui.adapter.ListItemType
@@ -229,9 +232,18 @@ abstract class MangaListFragment :
 		)
 	}
 
-	override fun onFilterOptionClick(option: ListFilterOption) {
+	override fun onFilterOptionClick(view: View, option: ListFilterOption) {
 		selectionController?.clear()
-		(viewModel as? QuickFilterListener)?.toggleFilterOption(option)
+		if (option is ListFilterOption.State) {
+			showStateFilterPopupMenu(view, option) { selectedState ->
+				(viewModel as? QuickFilterListener)?.setFilterOption(
+					ListFilterOption.State(selectedState),
+					isApplied = selectedState != null,
+				)
+			}
+		} else {
+			(viewModel as? QuickFilterListener)?.toggleFilterOption(option)
+		}
 	}
 
 	override fun onFilterClick(view: View?) = Unit

--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/StateFilterPopupMenu.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/StateFilterPopupMenu.kt
@@ -1,0 +1,83 @@
+package org.koitharu.kotatsu.list.ui
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import androidx.appcompat.widget.ListPopupWindow
+import androidx.core.content.ContextCompat
+import org.koitharu.kotatsu.R
+import org.koitharu.kotatsu.core.model.titleResId
+import org.koitharu.kotatsu.databinding.ItemPopupFilterStateBinding
+import org.koitharu.kotatsu.list.domain.ListFilterOption
+import org.koitharu.kotatsu.parsers.model.MangaState
+
+fun showStateFilterPopupMenu(
+	anchor: View,
+	currentOption: ListFilterOption.State,
+	onSelectState: (MangaState?) -> Unit,
+) {
+	val context = anchor.context
+	val currentState = currentOption.state
+	val density = context.resources.displayMetrics.density
+
+	val items = mutableListOf<StateMenuItem>()
+	items.add(
+		StateMenuItem(
+			state = null,
+			title = context.getString(R.string.publication_status),
+			isSelected = currentState == null,
+		),
+	)
+	for (state in MangaState.entries) {
+		items.add(
+			StateMenuItem(
+				state = state,
+				title = context.getString(state.titleResId),
+				isSelected = currentState == state,
+			),
+		)
+	}
+
+	val adapter = StateFilterAdapter(context, items)
+	val popup = ListPopupWindow(context, null, androidx.appcompat.R.attr.listPopupWindowStyle)
+	popup.anchorView = anchor
+	popup.setAdapter(adapter)
+	popup.isModal = true
+	popup.verticalOffset = (8 * density).toInt()
+	popup.horizontalOffset = (-16 * density).toInt()
+	popup.setBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.bg_popup_menu_rounded))
+	popup.setContentWidth((240 * density).toInt())
+
+	popup.setOnItemClickListener { _, _, position, _ ->
+		val selectedItem = items.getOrNull(position)
+		onSelectState(selectedItem?.state)
+		popup.dismiss()
+	}
+	popup.show()
+}
+
+private data class StateMenuItem(
+	val state: MangaState?,
+	val title: String,
+	val isSelected: Boolean,
+)
+
+private class StateFilterAdapter(
+	context: Context,
+	items: List<StateMenuItem>,
+) : ArrayAdapter<StateMenuItem>(context, 0, items) {
+
+	override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+		val binding = if (convertView != null) {
+			ItemPopupFilterStateBinding.bind(convertView)
+		} else {
+			ItemPopupFilterStateBinding.inflate(LayoutInflater.from(context), parent, false)
+		}
+		val item = getItem(position)
+		binding.textViewTitle.text = item?.title
+		binding.radioButton.isChecked = item?.isSelected == true
+		return binding.root
+	}
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/adapter/QuickFilterAD.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/adapter/QuickFilterAD.kt
@@ -29,7 +29,7 @@ private class WeakQuickFilterChipClickListener(
 
 	override fun onChipClick(chip: com.google.android.material.chip.Chip, data: Any?) {
 		if (data is ListFilterOption) {
-			listenerRef.get()?.onFilterOptionClick(data)
+			listenerRef.get()?.onFilterOptionClick(chip, data)
 		}
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/adapter/QuickFilterClickListener.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/adapter/QuickFilterClickListener.kt
@@ -1,8 +1,9 @@
 package org.koitharu.kotatsu.list.ui.adapter
 
+import android.view.View
 import org.koitharu.kotatsu.list.domain.ListFilterOption
 
 interface QuickFilterClickListener {
 
-	fun onFilterOptionClick(option: ListFilterOption)
+	fun onFilterOptionClick(view: View, option: ListFilterOption)
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/search/ui/multi/SearchActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/search/ui/multi/SearchActivity.kt
@@ -191,7 +191,7 @@ class SearchActivity :
 		viewModel.retry()
 	}
 
-	override fun onFilterOptionClick(option: ListFilterOption) = Unit
+	override fun onFilterOptionClick(view: View, option: ListFilterOption) = Unit
 
 	override fun onFilterClick(view: View?) = Unit
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedFragment.kt
@@ -4,6 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import org.koitharu.kotatsu.list.ui.showStateFilterPopupMenu
+import androidx.appcompat.widget.PopupMenu
+import org.koitharu.kotatsu.core.model.titleResId
+import org.koitharu.kotatsu.parsers.model.MangaState
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -104,7 +108,18 @@ class FeedFragment :
 		viewModel.update()
 	}
 
-	override fun onFilterOptionClick(option: ListFilterOption) = viewModel.toggleFilterOption(option)
+	override fun onFilterOptionClick(view: View, option: ListFilterOption) {
+		if (option is ListFilterOption.State) {
+			showStateFilterPopupMenu(view, option) { selectedState ->
+				viewModel.setFilterOption(
+					ListFilterOption.State(selectedState),
+					isApplied = selectedState != null,
+				)
+			}
+		} else {
+			viewModel.toggleFilterOption(option)
+		}
+	}
 
 	override fun onRetryClick(error: Throwable) = Unit
 

--- a/app/src/main/res/drawable/bg_popup_menu_rounded.xml
+++ b/app/src/main/res/drawable/bg_popup_menu_rounded.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+	<item>
+		<shape>
+			<solid android:color="?attr/colorSurface" />
+			<corners android:radius="16dp" />
+		</shape>
+	</item>
+	<item>
+		<shape>
+			<solid android:color="@color/m3_popupmenu_overlay_color" />
+			<corners android:radius="16dp" />
+		</shape>
+	</item>
+</layer-list>

--- a/app/src/main/res/layout/item_category_checkable.xml
+++ b/app/src/main/res/layout/item_category_checkable.xml
@@ -6,17 +6,30 @@
 	android:layout_height="wrap_content"
 	android:background="?selectableItemBackground"
 	android:minHeight="?listPreferredItemHeightSmall"
-	android:orientation="vertical"
+	android:orientation="horizontal"
+	android:gravity="center_vertical"
 	android:paddingStart="?listPreferredItemPaddingStart"
 	android:paddingEnd="?listPreferredItemPaddingEnd">
 
 	<com.google.android.material.checkbox.MaterialCheckBox
 		android:id="@+id/checkBox"
-		android:layout_width="match_parent"
+		android:layout_width="0dp"
 		android:layout_height="wrap_content"
+		android:layout_weight="1"
 		android:clickable="false"
 		android:gravity="center_vertical"
 		tools:checkedState="indeterminate"
 		tools:text="@tools:sample/cities" />
+
+	<TextView
+		android:id="@+id/textViewDate"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_marginStart="8dp"
+		android:textAppearance="?textAppearanceLabelSmall"
+		android:textColor="?android:textColorSecondary"
+		android:visibility="gone"
+		tools:text="14.05.2024"
+		tools:visibility="visible" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_popup_filter_state.xml
+++ b/app/src/main/res/layout/item_popup_filter_state.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="48dp"
+	android:background="?attr/selectableItemBackground"
+	android:gravity="center_vertical"
+	android:orientation="horizontal"
+	android:paddingStart="16dp"
+	android:paddingEnd="16dp">
+
+	<TextView
+		android:id="@+id/textViewTitle"
+		android:layout_width="0dp"
+		android:layout_height="wrap_content"
+		android:layout_weight="1"
+		android:ellipsize="end"
+		android:maxLines="1"
+		android:textAppearance="?attr/textAppearanceBodyMedium"
+		android:textColor="?attr/colorOnSurface" />
+
+	<RadioButton
+		android:id="@+id/radioButton"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:clickable="false"
+		android:focusable="false" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/layout_details_table.xml
+++ b/app/src/main/res/layout/layout_details_table.xml
@@ -304,7 +304,60 @@
 			</LinearLayout>
 		</LinearLayout>
 
-		<!-- Row 4: Chapters (full width) -->
+		<!-- Row 4: Favourite Date -->
+		<LinearLayout
+			android:id="@+id/meta_favourite_row"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:baselineAligned="false"
+			android:orientation="horizontal"
+			android:paddingVertical="10dp"
+			android:visibility="gone"
+			tools:visibility="visible">
+
+			<LinearLayout
+				android:id="@+id/meta_favourite_cell"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:gravity="center_vertical"
+				android:orientation="horizontal">
+
+				<ImageView
+					android:layout_width="16dp"
+					android:layout_height="16dp"
+					android:contentDescription="@null"
+					android:src="@drawable/ic_heart_outline"
+					app:tint="?colorPrimary" />
+
+				<LinearLayout
+					android:layout_width="0dp"
+					android:layout_height="wrap_content"
+					android:layout_marginStart="10dp"
+					android:layout_weight="1"
+					android:orientation="vertical">
+
+					<TextView
+						android:id="@+id/textView_favourite_label"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:letterSpacing="0.08"
+						android:singleLine="true"
+						android:text="@string/added_to_favourites"
+						android:textAppearance="?textAppearanceLabelSmall"
+						android:textColor="?android:textColorSecondary" />
+
+					<TextView
+						android:id="@+id/textView_favourite_date"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:singleLine="true"
+						android:textAppearance="?textAppearanceBodyMedium"
+						tools:text="05.09.2026" />
+				</LinearLayout>
+			</LinearLayout>
+		</LinearLayout>
+
+		<!-- Row 5: Chapters (full width) -->
 		<LinearLayout
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -881,4 +881,6 @@
     <string name="available_pattern">%1$s доступно</string>
     <string name="enter_name">Введите имя</string>
     <string name="translate_page">Перевести страницу</string>
+    <string name="added_to_favourites">В избранном с</string>
+    <string name="added_to_category_at">Добавлено в категорию «%1$s»: %2$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1218,6 +1218,8 @@
 	<string name="every_12_hours">Every 12 hours</string>
 	<string name="daily">Daily</string>
 	<string name="drive_sync_queued">Google Drive sync queued</string>
+	<string name="added_to_favourites">In favorites since</string>
+	<string name="added_to_category_at">Added to category \"%1$s\": %2$s</string>
 	<string name="manga_preferences">Per-manga reader settings and overrides</string>
 	<string name="sync_content">Content to synchronize</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,6 @@ android.enableJetifier=false
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx1536M -Dkotlin.daemon.jvm.options\="-Xmx1536M"
+org.gradle.jvmargs=-Xmx4096m -Dkotlin.daemon.jvm.options\="-Xmx4096m"
 android.enableR8.fullMode=true
 android.nonFinalResIds=false


### PR DESCRIPTION
## Summary of Changes

This Pull Request introduces UX improvements for quick filters, favorite creation date tracking across manga details and category dialogs, memory optimizations, and graceful secret handling for Discord webhooks.

### 1. Publication Status Dropdown Filter
- Changed the "Publication status" quick filter chip from single-item cycling on click to displaying a dropdown PopupMenu.
- Users can now click the chip to select any desired status directly (Ongoing, Finished, Abandoned, Paused, Upcoming, Restricted, or All).
- Styled with 8dp vertical offset, horizontal centering, custom item layouts, and 16dp rounded corners (g_popup_menu_rounded.xml).

### 2. Favorite Creation Date Display & Long-Press Tooltip
- **Manga Details Screen (DetailsActivity)**: Added a dynamic metadata row displaying when the manga was first added to favorites (In favorites since: <date>). Automatically expands to full width when local downloads exist or pairs with Rating when no local downloads exist.
- **Category Selection Dialog (FavoriteDialog)**: Displays a subtle date string on the right side for checked categories ([вњ“]).
- **Long-Press Tooltip**: Long-clicking a checked category item displays a Toast notification with full date and time details (Added to category "CategoryTitle": <date>, <time>).

### 3. Build & Memory Optimizations
- **Increased Heap Allocation**: Raised Gradle and Kotlin compiler daemon heap size in gradle.properties (-Xmx4096m) to prevent java.lang.OutOfMemoryError during Kotlin compilation and R8 minification in CI environments.

### 4. Discord Webhooks & Fork Compatibility
- Added graceful checks for all Discord webhook notifications (
ew-commit-discord.yml, 
ew-issue-discord.yml, 
ew-release-discord.yml):
  - If webhook secrets are missing (e.g. in forks or pull requests), steps skip cleanly without failing the job.
- **Smart Role Mentions**:
  - Preserves default role mentions (<@&1507819392233242624> and <@&1506992583744684175>) when running in the main repository (glitch-228/Kaisoku).
  - Allows custom role IDs via DISCORD_ROLE_ID secret in forks, or cleanly omits role mentions if unconfigured.